### PR TITLE
Refactor: streaming improvements

### DIFF
--- a/.c8rc
+++ b/.c8rc
@@ -1,5 +1,5 @@
 {
   "all": true,
-  "exclude": ["*.js", "*.d.ts", "**/*.test.ts", "types/"],
+  "exclude": ["*.js", "*.d.ts", "**/*.test.ts", "**/types/"],
   "reporter": ["text", "lcovonly"]
 }

--- a/exports/buffer.ts
+++ b/exports/buffer.ts
@@ -58,7 +58,7 @@ export class ZipBufferReader
         entry.localHeaderOffset,
       );
 
-      yield ZipEntryReader.fromBuffer(
+      yield new ZipEntryReader(
         entry,
         this.#buffer.getOriginalBytes(
           entry.localHeaderOffset + localHeaderSize,

--- a/exports/entry.test.ts
+++ b/exports/entry.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert";
 import { text } from "node:stream/consumers";
 import { describe, it } from "node:test";
-import { normalizeDataSource } from "../util/streams.ts";
 import {
   ZipEntry,
   ZipEntryBase,
@@ -219,7 +218,7 @@ describe("exports/entry", () => {
           new CentralDirectoryHeader({
             attributes: new DosFileAttributes(DosFileAttributes.System),
             comment: "the comment goes here",
-            compressedSize: 0x11223344,
+            compressedSize: 11,
             compressionMethod: 10,
             crc32: 222957957,
             extraField: new ExtraFieldCollection(),
@@ -231,7 +230,7 @@ describe("exports/entry", () => {
             versionMadeBy: ZipVersion.Utf8Encoding,
             versionNeeded: ZipVersion.Deflate,
           }),
-          () => new ReadableStream(),
+          Buffer.from("hello world"),
         );
         assert.throws(
           () => entry.open(),
@@ -242,33 +241,36 @@ describe("exports/entry", () => {
       });
 
       it("throws if the compressed size is wrong", async () => {
+        const header = new CentralDirectoryHeader({
+          attributes: new DosFileAttributes(DosFileAttributes.System),
+          comment: "the comment goes here",
+          compressedSize: 13,
+          compressionMethod: CompressionMethod.Stored,
+          crc32: 222957957,
+          extraField: new ExtraFieldCollection(),
+          flags: new GeneralPurposeFlags(GeneralPurposeFlags.HasEncryption),
+          lastModified: new Date(1747586332724),
+          localHeaderOffset: 0x44332211,
+          path: "here is the path",
+          uncompressedSize: 11,
+          versionMadeBy: ZipVersion.Utf8Encoding,
+          versionNeeded: ZipVersion.Deflate,
+        });
         const entry = new ZipEntryReader(
-          new CentralDirectoryHeader({
-            attributes: new DosFileAttributes(DosFileAttributes.System),
-            comment: "the comment goes here",
-            compressedSize: 11,
-            compressionMethod: CompressionMethod.Stored,
-            crc32: 222957957,
-            extraField: new ExtraFieldCollection(),
-            flags: new GeneralPurposeFlags(GeneralPurposeFlags.HasEncryption),
-            lastModified: new Date(1747586332724),
-            localHeaderOffset: 0x44332211,
-            path: "here is the path",
-            uncompressedSize: 22,
-            versionMadeBy: ZipVersion.Utf8Encoding,
-            versionNeeded: ZipVersion.Deflate,
-          }),
-          () => normalizeDataSource("hello world"),
+          header,
+          // needs to be a provider or the constructor will throw before we get
+          // to open()
+          () => Buffer.from("hello world"),
         );
         await assert.rejects(
           () => text(entry.open()),
           (error) =>
             error instanceof ZipFormatError &&
-            error.message === "entry size mismatch",
+            error.message === "entry compressed size mismatch",
         );
       });
 
-      it("throws if the crc32 size is wrong", async () => {
+      it("throws if the crc32 is wrong", async () => {
         const entry = new ZipEntryReader(
           new CentralDirectoryHeader({
             attributes: new DosFileAttributes(DosFileAttributes.System),
@@ -285,7 +287,7 @@ describe("exports/entry", () => {
             versionMadeBy: ZipVersion.Utf8Encoding,
             versionNeeded: ZipVersion.Deflate,
           }),
-          () => normalizeDataSource("hello world"),
+          Buffer.from("hello world"),
         );
         await assert.rejects(
           () => text(entry.open()),
@@ -302,7 +304,7 @@ describe("exports/entry", () => {
             comment: "the comment goes here",
             compressedSize: 11,
             compressionMethod: CompressionMethod.Stored,
-            crc32: 11,
+            crc32: 222957957,
             extraField: new ExtraFieldCollection(),
             flags: new GeneralPurposeFlags(GeneralPurposeFlags.HasEncryption),
             lastModified: new Date(1747586332724),
@@ -312,13 +314,13 @@ describe("exports/entry", () => {
             versionMadeBy: ZipVersion.Utf8Encoding,
             versionNeeded: ZipVersion.Deflate,
           }),
-          () => normalizeDataSource("hello world"),
+          Buffer.from("hello world"),
         );
         await assert.rejects(
           () => text(entry.open()),
           (error) =>
             error instanceof ZipFormatError &&
-            error.message === "entry size mismatch",
+            error.message === "entry uncompressed size mismatch",
         );
       });
     });
@@ -329,7 +331,7 @@ describe("exports/entry", () => {
           new CentralDirectoryHeader({
             attributes: new DosFileAttributes(DosFileAttributes.System),
             comment: "the comment goes here",
-            compressedSize: 11,
+            compressedSize: 16,
             compressionMethod: 123,
             crc32: 11,
             extraField: new ExtraFieldCollection(),
@@ -341,7 +343,7 @@ describe("exports/entry", () => {
             versionMadeBy: ZipVersion.Utf8Encoding,
             versionNeeded: ZipVersion.Deflate,
           }),
-          () => normalizeDataSource("still compressed"),
+          Buffer.from("still compressed"),
         );
 
         const data = await text(entry.openCompressed());

--- a/exports/entry.ts
+++ b/exports/entry.ts
@@ -138,7 +138,7 @@ export class ZipEntryReader
     return new this(header, () => {
       return new RandomAccessReaderStream({
         bufferSize,
-        headerLength: LocalFileHeader.FixedSize,
+        headerMinLength: LocalFileHeader.FixedSize,
         header: (chunk) => ({
           length: header.compressedSize,
           startPosition:

--- a/exports/entry.ts
+++ b/exports/entry.ts
@@ -4,10 +4,10 @@ import { computeCrc32 } from "../util/crc32.ts";
 import {
   CountBytesStream,
   Crc32Stream,
+  normalizeByteSourceProvider,
   normalizeDataSource,
-  RandomAccessReaderStream,
+  type ByteSourceProvider,
   type DataSource,
-  type RandomAccessReader,
 } from "../util/streams.ts";
 import { ZipFormatError } from "./errors.ts";
 import {
@@ -26,7 +26,6 @@ import {
   type FileAttributes,
 } from "./raw/file-attributes.ts";
 import { GeneralPurposeFlags } from "./raw/flags.ts";
-import { LocalFileHeader } from "./raw/local-file-header.ts";
 
 /**
  * Represents an entry in a zip file.
@@ -106,58 +105,17 @@ export class ZipEntryReader
   extends ZipEntryBase
   implements AsyncIterable<Uint8Array>
 {
-  /**
-   * Create a {@link ZipEntryReader} for buffered content.
-   */
-  public static fromBuffer(
-    header: CentralDirectoryHeader,
-    dataBuffer: Uint8Array,
-  ): ZipEntryReader {
-    assert(
-      dataBuffer.byteLength === header.compressedSize,
-      `supplied data length must match compressedSize in header`,
-    );
-    return new this(header, () => {
-      return new ReadableStream({
-        start: (controller) => {
-          controller.enqueue(dataBuffer);
-          controller.close();
-        },
-      });
-    });
-  }
-
-  /**
-   * Create a {@link ZipEntryReader} for a {@link RandomAccessReader}.
-   */
-  public static fromRandomAccessReader(
-    header: CentralDirectoryHeader,
-    reader: RandomAccessReader,
-    bufferSize = 0x20000,
-  ): ZipEntryReader {
-    return new this(header, () => {
-      return new RandomAccessReaderStream({
-        bufferSize,
-        headerMinLength: LocalFileHeader.FixedSize,
-        header: (chunk) => ({
-          length: header.compressedSize,
-          startPosition:
-            header.localHeaderOffset + LocalFileHeader.readTotalSize(chunk),
-        }),
-        reader,
-        startPosition: header.localHeaderOffset,
-      });
-    });
-  }
-
   readonly #data: () => ReadableStream<Uint8Array>;
 
-  public constructor(
-    header: CentralDirectoryHeader,
-    data: () => ReadableStream<Uint8Array>,
-  ) {
+  public constructor(header: CentralDirectoryHeader, data: ByteSourceProvider) {
     super(header);
-    this.#data = data;
+    if (data instanceof Uint8Array) {
+      assert(
+        data.byteLength === header.compressedSize,
+        `supplied data length must match compressed size in header`,
+      );
+    }
+    this.#data = normalizeByteSourceProvider(data);
   }
 
   public [Symbol.asyncIterator](): AsyncIterator<Uint8Array, void, void> {
@@ -168,7 +126,14 @@ export class ZipEntryReader
    * Returns a stream for the uncompressed data.
    */
   public open(): ReadableStream<Uint8Array> {
-    let source = this.#data();
+    let source = this.#data().pipeThrough(
+      new CountBytesStream((count) => {
+        if (count !== this.compressedSize) {
+          throw new ZipFormatError(`entry compressed size mismatch`);
+        }
+      }),
+    );
+
     if (this.compressionMethod === CompressionMethod.Deflate) {
       source = source.pipeThrough(new DecompressionStream("deflate-raw"));
     } else if (this.compressionMethod !== CompressionMethod.Stored) {
@@ -180,7 +145,7 @@ export class ZipEntryReader
       .pipeThrough(
         new CountBytesStream((count) => {
           if (count !== this.uncompressedSize) {
-            throw new ZipFormatError(`entry size mismatch`);
+            throw new ZipFormatError(`entry uncompressed size mismatch`);
           }
         }),
       )

--- a/exports/raw/central-directory-header.test.ts
+++ b/exports/raw/central-directory-header.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
-import { describe, it } from "node:test";
-import { assertBufferEqual } from "../../test-util/assert.ts";
+import { describe, it, mock } from "node:test";
+import { assertBufferEqual, assertInstanceOf } from "../../test-util/assert.ts";
 import {
   bigUint,
   cp437,
@@ -13,7 +13,8 @@ import {
   utf8,
   utf8length,
 } from "../../test-util/data.ts";
-import { normalizeDataSource } from "../../util/streams.ts";
+import { Zip32CentralDirectoryWithThreeEntries } from "../../test-util/fixtures.ts";
+import { normalizeByteSource } from "../../util/streams.ts";
 import {
   MultiDiskError,
   ZipFormatError,
@@ -741,8 +742,23 @@ describe("exports/raw/central-directory-header", () => {
 
   describe("class CentralDirectoryStream", () => {
     describe("iteration", () => {
+      it("returns 0 entries without reading the source if the entry count is 0", async () => {
+        const data = normalizeByteSource(new Uint8Array());
+        const getReader = mock.method(data, "getReader");
+
+        const readable = new CentralDirectoryStream(data, {
+          entryCount: 0,
+        });
+
+        const reader = readable.getReader();
+        const next = await reader.read();
+
+        assert.strictEqual(next.done, true);
+        assert.strictEqual(getReader.mock.callCount(), 0);
+      });
+
       it("throws ZipFormatError if size is too small for number of entries", async () => {
-        const data = normalizeDataSource(new Uint8Array(10));
+        const data = normalizeByteSource(new Uint8Array(10));
 
         const readable = new CentralDirectoryStream(data, {
           entryCount: 1,
@@ -753,6 +769,47 @@ describe("exports/raw/central-directory-header", () => {
           () => reader.read(),
           (error) => error instanceof ZipFormatError,
         );
+      });
+
+      it("can read successfully with small data chunks", async () => {
+        const source = Zip32CentralDirectoryWithThreeEntries;
+        const smallChunks: Uint8Array[] = [];
+
+        // read the first header completely in two chunks, to cover all branches
+        const chunkSizes = [30, 31];
+
+        for (let offset = 0, i = 0; offset < source.byteLength; ++i) {
+          const chunkSize = chunkSizes[i] ?? 10;
+          smallChunks.push(source.subarray(offset, offset + chunkSize));
+          offset += chunkSize;
+        }
+
+        const directory = new CentralDirectoryStream(smallChunks, {
+          entryCount: 3,
+        });
+
+        const reader = directory.getReader();
+
+        const next = await reader.read();
+        assert(!next.done);
+        assertInstanceOf(next.value.attributes, UnixFileAttributes);
+        assert.strictEqual(next.value.attributes.value, 0o10_0644);
+        assert.strictEqual(next.value.comment, "comment 1");
+        assert.strictEqual(next.value.compressedSize, 26);
+        assert.strictEqual(next.value.compressionMethod, 0);
+        assert.strictEqual(next.value.crc32, 776234292);
+        assert.strictEqual(next.value.extraField.fields.length, 0);
+        assert.strictEqual(next.value.flags.value, 0);
+        assert.strictEqual(
+          next.value.lastModified.getTime(),
+          new Date("2023-04-05T11:22:34Z").getTime(),
+        );
+        assert.strictEqual(next.value.localHeaderOffset, 0);
+        assert.strictEqual(next.value.path, "path 1");
+        assert.strictEqual(next.value.platformMadeBy, 3);
+        assert.strictEqual(next.value.uncompressedSize, 26);
+        assert.strictEqual(next.value.versionMadeBy, 20);
+        assert.strictEqual(next.value.versionNeeded, 20);
       });
     });
   });

--- a/exports/raw/central-directory-header.test.ts
+++ b/exports/raw/central-directory-header.test.ts
@@ -13,10 +13,7 @@ import {
   utf8,
   utf8length,
 } from "../../test-util/data.ts";
-import {
-  normalizeDataSource,
-  randomAccessReaderFromBuffer,
-} from "../../util/streams.ts";
+import { normalizeDataSource } from "../../util/streams.ts";
 import {
   MultiDiskError,
   ZipFormatError,
@@ -25,8 +22,8 @@ import {
 import {
   CentralDirectoryBufferReader,
   CentralDirectoryHeader,
-  CentralDirectoryRandomAccessReader,
   CentralDirectoryStream,
+  CentralDirectoryStreamReader,
 } from "./central-directory-header.ts";
 import {
   CompressionMethod,
@@ -716,9 +713,7 @@ describe("exports/raw/central-directory-header", () => {
   describe("class CentralDirectoryRandomAccessReader", () => {
     describe("constructor", () => {
       it("sets the instance properties", () => {
-        const data = randomAccessReaderFromBuffer(new Uint8Array(1024));
-
-        const reader = new CentralDirectoryRandomAccessReader(
+        const reader = new CentralDirectoryStreamReader(
           {
             comment: "comment here",
             count: 10,
@@ -730,7 +725,7 @@ describe("exports/raw/central-directory-header", () => {
               versionNeeded: ZipVersion.Utf8Encoding,
             },
           },
-          { reader: data, bufferSize: 100 },
+          new Uint8Array(1024),
         );
 
         assert.strictEqual(reader.comment, "comment here");
@@ -749,7 +744,9 @@ describe("exports/raw/central-directory-header", () => {
       it("throws ZipFormatError if size is too small for number of entries", async () => {
         const data = normalizeDataSource(new Uint8Array(10));
 
-        const readable = CentralDirectoryStream.from(data, { entryCount: 1 });
+        const readable = CentralDirectoryStream.from(data, {
+          entryCount: 1,
+        });
 
         const reader = readable.getReader();
         await assert.rejects(

--- a/exports/raw/central-directory-header.test.ts
+++ b/exports/raw/central-directory-header.test.ts
@@ -744,7 +744,7 @@ describe("exports/raw/central-directory-header", () => {
       it("throws ZipFormatError if size is too small for number of entries", async () => {
         const data = normalizeDataSource(new Uint8Array(10));
 
-        const readable = CentralDirectoryStream.from(data, {
+        const readable = new CentralDirectoryStream(data, {
           entryCount: 1,
         });
 

--- a/exports/raw/central-directory-header.test.ts
+++ b/exports/raw/central-directory-header.test.ts
@@ -13,7 +13,10 @@ import {
   utf8,
   utf8length,
 } from "../../test-util/data.ts";
-import { randomAccessReaderFromBuffer } from "../../util/streams.ts";
+import {
+  normalizeDataSource,
+  randomAccessReaderFromBuffer,
+} from "../../util/streams.ts";
 import {
   MultiDiskError,
   ZipFormatError,
@@ -23,7 +26,7 @@ import {
   CentralDirectoryBufferReader,
   CentralDirectoryHeader,
   CentralDirectoryRandomAccessReader,
-  CentralDirectoryReadableStream,
+  CentralDirectoryStream,
 } from "./central-directory-header.ts";
 import {
   CompressionMethod,
@@ -741,20 +744,12 @@ describe("exports/raw/central-directory-header", () => {
     });
   });
 
-  describe("class CentralDirectoryReadableStream", () => {
+  describe("class CentralDirectoryStream", () => {
     describe("iteration", () => {
       it("throws ZipFormatError if size is too small for number of entries", async () => {
-        const data = randomAccessReaderFromBuffer(new Uint8Array(10));
+        const data = normalizeDataSource(new Uint8Array(10));
 
-        const readable = new CentralDirectoryReadableStream(
-          {
-            comment: "",
-            count: 10,
-            offset: 0,
-            size: 10,
-          },
-          { reader: data, bufferSize: 100 },
-        );
+        const readable = CentralDirectoryStream.from(data, { entryCount: 1 });
 
         const reader = readable.getReader();
         await assert.rejects(

--- a/exports/raw/central-directory-header.ts
+++ b/exports/raw/central-directory-header.ts
@@ -1,3 +1,4 @@
+import { assert } from "../../util/assert.ts";
 import { BufferView, type BufferLike } from "../../util/binary.ts";
 import { DosDate } from "../../util/dos-date.ts";
 import { EncodedString } from "../../util/encoded-string.ts";
@@ -151,6 +152,16 @@ export class CentralDirectoryHeader
     byteOffset?: number,
     byteLength?: number,
   ): number {
+    return (
+      this.FixedSize + this.readVariableSize(buffer, byteOffset, byteLength)
+    );
+  }
+
+  public static readVariableSize(
+    buffer: BufferLike,
+    byteOffset?: number,
+    byteLength?: number,
+  ): number {
     const view = new BufferView(buffer, byteOffset, byteLength);
     const signature = view.readUint32LE(0);
 
@@ -162,12 +173,7 @@ export class CentralDirectoryHeader
     const extraFieldLength = view.readUint16LE(30);
     const commentLength = view.readUint16LE(32);
 
-    return (
-      CentralDirectoryHeader.FixedSize +
-      pathLength +
-      extraFieldLength +
-      commentLength
-    );
+    return pathLength + extraFieldLength + commentLength;
   }
 
   public attributes: FileAttributes;
@@ -386,7 +392,7 @@ export class CentralDirectoryStreamReader implements CentralDirectoryReader {
     void,
     void
   > {
-    const reader = CentralDirectoryStream.from(this.#source(), {
+    const reader = new CentralDirectoryStream(this.#source(), {
       entryCount: this.#trailer.count,
     });
 
@@ -398,62 +404,192 @@ export type CentralDirectoryStreamOptions = {
   entryCount: number;
 };
 
-export class CentralDirectoryStream extends TransformStream<
-  Uint8Array,
-  CentralDirectoryHeader
-> {
-  public static from(
-    readable: ByteSource,
-    options: CentralDirectoryStreamOptions,
-  ): ReadableStream<CentralDirectoryHeader> {
-    return normalizeByteSource(readable).pipeThrough(
-      new CentralDirectoryStream(options),
-    );
-  }
+export class CentralDirectoryStream extends ReadableStream<CentralDirectoryHeader> {
+  readonly #source: ReadableStreamDefaultReader<Uint8Array>;
+  readonly #entryCount: number;
 
+  #controller!: ReadableStreamDefaultController<CentralDirectoryHeader>;
   #headersRead = 0;
-  #lastChunk: Uint8Array | undefined;
+  #buffer = new Uint8Array(256);
+  #bufferSize = 0;
+  #bufferTarget = 0;
 
-  public constructor(options: CentralDirectoryStreamOptions) {
+  public constructor(
+    source: ByteSource,
+    options: CentralDirectoryStreamOptions,
+  ) {
     super({
-      transform: (newChunk, controller) => {
-        this.#processChunk(newChunk, controller);
+      start: async (controller) => {
+        if (options.entryCount === 0) {
+          controller.close();
+          return;
+        }
+        // finish constructing first
+        await Promise.resolve();
+        this.#controller = controller;
       },
-      flush: () => {
-        if (this.#headersRead !== options.entryCount) {
-          throw new ZipFormatError("central directory size mismatch");
+
+      pull: async (controller) => {
+        try {
+          await this.#pull();
+        } catch (error) {
+          controller.error(error);
+          await this.#source.cancel();
         }
       },
     });
+    this.#entryCount = options.entryCount;
+    this.#source = normalizeByteSource(source).getReader();
   }
 
-  #processChunk(
-    newChunk: Uint8Array,
-    controller: TransformStreamDefaultController<CentralDirectoryHeader>,
-  ): void {
-    let chunk: Uint8Array;
-    if (this.#lastChunk) {
-      chunk = new Uint8Array(this.#lastChunk.byteLength + newChunk.length);
-      chunk.set(this.#lastChunk);
-      chunk.set(newChunk, this.#lastChunk.byteLength);
-    } else {
-      chunk = newChunk;
+  #bufferChunk(chunk: Uint8Array): void {
+    if (this.#bufferTarget > this.#buffer.byteLength) {
+      const oldBuffer = this.#buffer;
+      this.#buffer = new Uint8Array(this.#bufferTarget);
+      this.#buffer.set(oldBuffer.subarray(0, this.#bufferSize));
+      this.#buffer.set(chunk, this.#bufferSize);
     }
+
+    this.#buffer.set(chunk, this.#bufferSize);
+    this.#bufferSize = this.#bufferSize + chunk.byteLength;
+  }
+
+  #emit(header: CentralDirectoryHeader): void {
+    ++this.#headersRead;
+    this.#controller.enqueue(header);
+  }
+
+  #processChunk(newChunk: Uint8Array): number {
+    const currentCount = this.#headersRead;
+
     let offset = 0;
-    while (offset + CentralDirectoryHeader.FixedSize < chunk.byteLength) {
-      const headerLength = CentralDirectoryHeader.readTotalSize(chunk, offset);
-      if (offset + headerLength > chunk.byteLength) {
-        // can't read the whole thing
-        break;
+    do {
+      offset = this.#processEntry(newChunk, offset);
+    } while (offset);
+
+    // return number read from this chunk
+    return this.#headersRead - currentCount;
+  }
+
+  #processEntry(newChunk: Uint8Array, byteOffset: number): number {
+    if (this.#bufferTarget > 0) {
+      // we have something in the buffer and we already parsed the header length
+      // into #bufferTarget
+
+      // we should only have an offset if we're processing the chunk, not buffer
+      assert(byteOffset === 0);
+
+      if (this.#bufferTarget - this.#bufferSize > newChunk.byteLength) {
+        // we still don't have enough, so add the chunk on to the existing buffer
+        this.#bufferChunk(newChunk);
+        return 0;
       }
-      controller.enqueue(CentralDirectoryHeader.deserialize(chunk, offset));
-      ++this.#headersRead;
-      offset += headerLength;
+      // we now have enough data to process an entry
+      const nextOffset = this.#bufferTarget - this.#bufferSize;
+      // buffer what we need from the new chunk
+      this.#bufferChunk(newChunk.subarray(0, nextOffset));
+      // parse and reset the buffer
+      this.#emit(this.#unbufferEntry());
+      // return the offset in newChunk of the next header
+      return nextOffset;
+    } else if (this.#bufferSize > 0) {
+      // we have something in the buffer but didn't already read the length
+
+      // we should only have an offset if we're processing the chunk, not buffer
+      assert(byteOffset === 0);
+
+      const requiredBytes = CentralDirectoryHeader.FixedSize - this.#bufferSize;
+      assert(requiredBytes > 0);
+
+      if (requiredBytes > newChunk.byteLength) {
+        // we still don't have enough for the fixed fields, so buffer and return
+        this.#bufferChunk(newChunk);
+        return 0;
+      }
+
+      // we now have enough for the fixed fields so read the total length
+      this.#bufferChunk(newChunk.subarray(0, requiredBytes));
+      const newChunkRemaining = newChunk.byteLength - requiredBytes;
+
+      const variableLength = CentralDirectoryHeader.readVariableSize(
+        this.#buffer,
+        0,
+        this.#bufferSize,
+      );
+      const headerLength = CentralDirectoryHeader.FixedSize + variableLength;
+
+      if (variableLength > newChunkRemaining) {
+        // we don't have enough for the whole header, but we know how much we
+        // need now
+        this.#bufferTarget = headerLength;
+        // buffer the rest of the chunk, skipping the bit we already buffered
+        this.#bufferChunk(newChunk.subarray(requiredBytes));
+        return 0;
+      }
+
+      const nextOffset = requiredBytes + variableLength;
+
+      // we now have enough data to process an entry - buffer the remaining header
+      this.#bufferChunk(newChunk.subarray(requiredBytes, nextOffset));
+      // parse and reset the buffer
+      this.#emit(this.#unbufferEntry());
+      // return the offset in new chunk of the next header
+      return nextOffset;
     }
-    if (offset === chunk.byteLength) {
-      this.#lastChunk = undefined;
-    } else if (offset < chunk.byteLength) {
-      this.#lastChunk = chunk.subarray(offset);
+
+    const availableBytes = newChunk.byteLength - byteOffset;
+    if (availableBytes < CentralDirectoryHeader.FixedSize) {
+      // there's nothing in the buffer and the new chunk is too short
+      this.#bufferChunk(newChunk.subarray(byteOffset));
+      return 0;
     }
+
+    // there's nothing in the buffer and the new chunk is at least long enough
+    // to read the total length
+
+    const headerLength = CentralDirectoryHeader.readTotalSize(
+      newChunk,
+      byteOffset,
+    );
+    if (availableBytes >= headerLength) {
+      // we have enough data to read the whole header
+      this.#emit(CentralDirectoryHeader.deserialize(newChunk, byteOffset));
+      // return the offset in newChunk of the next header
+      return byteOffset + headerLength;
+    }
+
+    // we don't have enough data for the variable fields
+    this.#bufferTarget = headerLength;
+    this.#bufferChunk(newChunk.subarray(byteOffset));
+    return 0;
+  }
+
+  async #pull(): Promise<void> {
+    // loop until we read at least one entry
+    let chunk: Uint8Array;
+    do {
+      const next = await this.#source.read();
+      if (next.done) {
+        throw new ZipFormatError("unexpected end of data");
+      }
+      chunk = next.value;
+    } while (this.#processChunk(chunk) === 0);
+
+    if (this.#headersRead >= this.#entryCount) {
+      this.#controller.close();
+      await this.#source.cancel();
+    }
+  }
+
+  #unbufferEntry(): CentralDirectoryHeader {
+    const header = CentralDirectoryHeader.deserialize(
+      this.#buffer,
+      0,
+      this.#bufferSize,
+    );
+
+    this.#bufferSize = 0;
+    this.#bufferTarget = 0;
+    return header;
   }
 }

--- a/exports/raw/central-directory-header.ts
+++ b/exports/raw/central-directory-header.ts
@@ -1,9 +1,11 @@
-import { assert } from "../../util/assert.ts";
 import { BufferView, type BufferLike } from "../../util/binary.ts";
 import { DosDate } from "../../util/dos-date.ts";
 import { EncodedString } from "../../util/encoded-string.ts";
 import { makeBuffer, type Serializable } from "../../util/serialization.ts";
-import { read, type RandomAccessReader } from "../../util/streams.ts";
+import {
+  RandomAccessReaderStream,
+  type RandomAccessReader,
+} from "../../util/streams.ts";
 import {
   MultiDiskError,
   ZipFormatError,
@@ -392,116 +394,77 @@ export class CentralDirectoryRandomAccessReader
     void,
     void
   > {
-    const reader = new CentralDirectoryReadableStream(
-      this.#trailer,
-      this.#options,
-    );
+    const source = new RandomAccessReaderStream({
+      ...this.#options,
+      startPosition: this.#trailer.offset,
+      length: this.#trailer.size,
+    });
+    const reader = CentralDirectoryStream.from(source, {
+      entryCount: this.#trailer.count,
+    });
+
     return reader[Symbol.asyncIterator]();
   }
 }
 
-export class CentralDirectoryReadableStream extends ReadableStream<CentralDirectoryHeader> {
-  readonly #buffer: Uint8Array;
-  readonly #endPosition: number;
-  readonly #entryCount: number;
-  readonly #reader: RandomAccessReader;
+export type CentralDirectoryStreamOptions = {
+  entryCount: number;
+};
 
-  #readCount = 0;
-  #currentOffset = 0;
-  #currentPosition: number;
-  #endOffset = 0;
+export class CentralDirectoryStream extends TransformStream<
+  Uint8Array,
+  CentralDirectoryHeader
+> {
+  public static from(
+    readable: ReadableStream<Uint8Array>,
+    options: CentralDirectoryStreamOptions,
+  ): ReadableStream<CentralDirectoryHeader> {
+    return readable.pipeThrough(new CentralDirectoryStream(options));
+  }
 
-  public constructor(
-    trailer: ZipTrailerFields,
-    options: CentralDirectoryRandomAccessReaderOptions,
-  ) {
+  #headersRead = 0;
+  #lastChunk: Uint8Array | undefined;
+
+  public constructor(options: CentralDirectoryStreamOptions) {
     super({
-      pull: async (controller) => {
-        await this.#pull(controller);
+      transform: (newChunk, controller) => {
+        this.#processChunk(newChunk, controller);
+      },
+      flush: () => {
+        if (this.#headersRead !== options.entryCount) {
+          throw new ZipFormatError("central directory size mismatch");
+        }
       },
     });
-
-    this.#buffer = new Uint8Array(options.bufferSize);
-    this.#currentPosition = trailer.offset;
-    this.#endPosition = trailer.offset + trailer.size;
-    this.#entryCount = trailer.count;
-    this.#reader = options.reader;
   }
 
-  async #fillBuffer(minLength?: number): Promise<void> {
-    if (minLength === undefined) {
-      await this.#fillBuffer(CentralDirectoryHeader.FixedSize);
-
-      const size = CentralDirectoryHeader.readTotalSize(
-        this.#buffer,
-        this.#currentOffset,
-      );
-      await this.#fillBuffer(size);
-      return;
+  #processChunk(
+    newChunk: Uint8Array,
+    controller: TransformStreamDefaultController<CentralDirectoryHeader>,
+  ): void {
+    let chunk: Uint8Array;
+    if (this.#lastChunk) {
+      chunk = new Uint8Array(this.#lastChunk.byteLength + newChunk.length);
+      chunk.set(this.#lastChunk);
+      chunk.set(newChunk, this.#lastChunk.byteLength);
+    } else {
+      chunk = newChunk;
     }
-
-    if (this.#haveBytes(minLength)) {
-      return;
-    }
-
-    // we end up re-reading a small portion at the end of the buffer, but
-    // it's too small for there to be any benefit to trying to avoid that
-    this.#currentPosition += this.#currentOffset;
-    this.#currentOffset = 0;
-
-    const maxLength = Math.min(
-      this.#buffer.length,
-      this.#endPosition - this.#currentPosition,
-    );
-    if (minLength > maxLength) {
-      throw new ZipFormatError("unexpected end of file");
-    }
-
-    this.#endOffset = await read(this.#reader, {
-      buffer: this.#buffer,
-      position: this.#currentPosition,
-      minLength,
-      maxLength,
-    });
-  }
-
-  #haveBytes(count: number): boolean {
-    return this.#currentOffset + count <= this.#endOffset;
-  }
-
-  async #pull(controller: ReadableStreamDefaultController): Promise<void> {
-    if (this.#readCount === this.#entryCount) {
-      controller.close();
-      return;
-    }
-    assert(this.#readCount < this.#entryCount);
-
-    await this.#fillBuffer();
-    controller.enqueue(this.#readOne());
-
-    while (
-      this.#readCount < this.#entryCount &&
-      this.#haveBytes(CentralDirectoryHeader.FixedSize)
-    ) {
-      const headerLength = CentralDirectoryHeader.readTotalSize(
-        this.#buffer,
-        this.#currentOffset,
-      );
-      // don't have enough bytes left to read the whole header
-      if (!this.#haveBytes(headerLength)) {
+    let offset = 0;
+    while (offset + CentralDirectoryHeader.FixedSize < chunk.byteLength) {
+      const headerLength = CentralDirectoryHeader.readTotalSize(chunk, offset);
+      if (offset + headerLength > chunk.byteLength) {
+        // can't read the whole thing
         break;
       }
-      controller.enqueue(this.#readOne());
+      controller.enqueue(CentralDirectoryHeader.deserialize(chunk, offset));
+      ++this.#headersRead;
+      offset += headerLength;
     }
-  }
-
-  #readOne(): CentralDirectoryHeader {
-    const entry = CentralDirectoryHeader.deserialize(
-      this.#buffer,
-      this.#currentOffset,
-    );
-    ++this.#readCount;
-    this.#currentOffset += entry.totalSize;
-    return entry;
+    if (offset === chunk.byteLength) {
+      this.#lastChunk = undefined;
+    } else if (offset < chunk.byteLength) {
+      this.#lastChunk = chunk.subarray(offset);
+    }
   }
 }

--- a/exports/raw/central-directory-header.ts
+++ b/exports/raw/central-directory-header.ts
@@ -3,8 +3,10 @@ import { DosDate } from "../../util/dos-date.ts";
 import { EncodedString } from "../../util/encoded-string.ts";
 import { makeBuffer, type Serializable } from "../../util/serialization.ts";
 import {
-  RandomAccessReaderStream,
-  type RandomAccessReader,
+  normalizeByteSource,
+  normalizeByteSourceProvider,
+  type ByteSource,
+  type ByteSourceProvider,
 } from "../../util/streams.ts";
 import {
   MultiDiskError,
@@ -354,16 +356,9 @@ export class CentralDirectoryBufferReader
   }
 }
 
-export type CentralDirectoryRandomAccessReaderOptions = {
-  bufferSize: number;
-  reader: RandomAccessReader;
-};
-
-export class CentralDirectoryRandomAccessReader
-  implements CentralDirectoryReader
-{
+export class CentralDirectoryStreamReader implements CentralDirectoryReader {
+  readonly #source: () => ReadableStream<Uint8Array>;
   readonly #trailer: ZipTrailerFields;
-  readonly #options: CentralDirectoryRandomAccessReaderOptions;
 
   public get size(): number {
     return this.#trailer.size;
@@ -381,12 +376,9 @@ export class CentralDirectoryRandomAccessReader
     return this.#trailer.zip64;
   }
 
-  public constructor(
-    trailer: ZipTrailerFields,
-    options: CentralDirectoryRandomAccessReaderOptions,
-  ) {
+  public constructor(trailer: ZipTrailerFields, source: ByteSourceProvider) {
+    this.#source = normalizeByteSourceProvider(source);
     this.#trailer = trailer;
-    this.#options = options;
   }
 
   public [Symbol.asyncIterator](): AsyncIterableIterator<
@@ -394,12 +386,7 @@ export class CentralDirectoryRandomAccessReader
     void,
     void
   > {
-    const source = new RandomAccessReaderStream({
-      ...this.#options,
-      startPosition: this.#trailer.offset,
-      length: this.#trailer.size,
-    });
-    const reader = CentralDirectoryStream.from(source, {
+    const reader = CentralDirectoryStream.from(this.#source(), {
       entryCount: this.#trailer.count,
     });
 
@@ -416,10 +403,12 @@ export class CentralDirectoryStream extends TransformStream<
   CentralDirectoryHeader
 > {
   public static from(
-    readable: ReadableStream<Uint8Array>,
+    readable: ByteSource,
     options: CentralDirectoryStreamOptions,
   ): ReadableStream<CentralDirectoryHeader> {
-    return readable.pipeThrough(new CentralDirectoryStream(options));
+    return normalizeByteSource(readable).pipeThrough(
+      new CentralDirectoryStream(options),
+    );
   }
 
   #headersRead = 0;

--- a/exports/raw/central-directory-header.ts
+++ b/exports/raw/central-directory-header.ts
@@ -405,7 +405,7 @@ export type CentralDirectoryStreamOptions = {
 };
 
 export class CentralDirectoryStream extends ReadableStream<CentralDirectoryHeader> {
-  readonly #source: ReadableStreamDefaultReader<Uint8Array>;
+  readonly #source: ReadableStreamDefaultReader<Uint8Array> | undefined;
   readonly #entryCount: number;
 
   #controller!: ReadableStreamDefaultController<CentralDirectoryHeader>;
@@ -434,12 +434,16 @@ export class CentralDirectoryStream extends ReadableStream<CentralDirectoryHeade
           await this.#pull();
         } catch (error) {
           controller.error(error);
-          await this.#source.cancel();
+          await this.#source?.cancel();
         }
       },
     });
+
     this.#entryCount = options.entryCount;
-    this.#source = normalizeByteSource(source).getReader();
+
+    if (options.entryCount > 0) {
+      this.#source = normalizeByteSource(source).getReader();
+    }
   }
 
   #bufferChunk(chunk: Uint8Array): void {
@@ -565,6 +569,7 @@ export class CentralDirectoryStream extends ReadableStream<CentralDirectoryHeade
   }
 
   async #pull(): Promise<void> {
+    assert(this.#source);
     // loop until we read at least one entry
     let chunk: Uint8Array;
     do {

--- a/exports/reader.test.ts
+++ b/exports/reader.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert";
+import { Readable } from "node:stream";
 import { buffer, text } from "node:stream/consumers";
 import { describe, it, mock } from "node:test";
 import { assertInstanceOf } from "../test-util/assert.ts";
@@ -18,7 +19,8 @@ import {
 } from "./raw/central-directory-header.ts";
 import { CompressionMethod, ZipPlatform, ZipVersion } from "./raw/constants.ts";
 import { UnixFileAttributes } from "./raw/file-attributes.ts";
-import { ZipReader } from "./reader.ts";
+import { LocalFileHeader } from "./raw/local-file-header.ts";
+import { ZipReader, type OpenStreamOptions } from "./reader.ts";
 
 describe("exports/reader", () => {
   describe("class ZipReader", () => {
@@ -247,6 +249,129 @@ describe("exports/reader", () => {
         assert.strictEqual(file2.isFile, false);
 
         assert.strictEqual(await text(file2), "");
+      });
+
+      describe("the returned ZipEntry instance", () => {
+        it("only reads the local header once", async () => {
+          const bufferReader = randomAccessReaderFromBuffer(
+            Zip32WithThreeEntries,
+          );
+          const read = mock.method(bufferReader, "read");
+
+          const reader = new ZipReader(
+            bufferReader,
+            Zip32WithThreeEntries.byteLength,
+          );
+
+          const firstEntryResult = await reader.files().next();
+          assert(!firstEntryResult.done);
+          const firstEntry = firstEntryResult.value;
+
+          const fileData1 = await text(firstEntry.open());
+          const fileData2 = await text(firstEntry.open());
+
+          const expectedContent = "this is the file 1 content";
+          assert.strictEqual(fileData1, expectedContent);
+          assert.strictEqual(fileData2, expectedContent);
+
+          // central dir + file header + file data + file data
+          assert.strictEqual(read.mock.callCount(), 4);
+
+          // central dir read
+          assert.partialDeepStrictEqual(read.mock.calls[0]?.arguments[0], {
+            position: 0,
+            length: Zip32WithThreeEntries.byteLength,
+          });
+
+          // file header read
+          assert.partialDeepStrictEqual(read.mock.calls[1]?.arguments[0], {
+            position: 0,
+            length: LocalFileHeader.FixedSize,
+          });
+
+          // data read 1
+          assert.partialDeepStrictEqual(read.mock.calls[2]?.arguments[0], {
+            position: 36,
+            length: 26,
+          });
+
+          // data read 2
+          assert.partialDeepStrictEqual(read.mock.calls[2]?.arguments[0], {
+            position: 36,
+            length: 26,
+          });
+        });
+
+        it("uses the openStream implementation if provided", async () => {
+          const bufferReader = randomAccessReaderFromBuffer(
+            Zip32WithThreeEntries,
+          );
+          const read = mock.method(bufferReader, "read");
+
+          const openStream = mock.fn((opts: OpenStreamOptions) =>
+            Buffer.from("this is the file 1 content"),
+          );
+
+          const reader = new ZipReader(
+            bufferReader,
+            Zip32WithThreeEntries.byteLength,
+            { openStream },
+          );
+
+          const firstEntryResult = await reader.files().next();
+          assert(!firstEntryResult.done);
+          const firstEntry = firstEntryResult.value;
+
+          const fileData = await text(firstEntry.open());
+
+          const expectedContent = "this is the file 1 content";
+          assert.strictEqual(fileData, expectedContent);
+
+          assert.strictEqual(openStream.mock.callCount(), 1);
+
+          assert.deepStrictEqual(openStream.mock.calls[0]?.arguments[0], {
+            startPosition: 36,
+            length: 26,
+          });
+
+          // central dir + file header
+          assert.strictEqual(read.mock.callCount(), 2);
+
+          // central dir read
+          assert.partialDeepStrictEqual(read.mock.calls[0]?.arguments[0], {
+            position: 0,
+            length: Zip32WithThreeEntries.byteLength,
+          });
+
+          // file header read
+          assert.partialDeepStrictEqual(read.mock.calls[1]?.arguments[0], {
+            position: 0,
+            length: LocalFileHeader.FixedSize,
+          });
+        });
+
+        it("accepts a Node Readable from openStream", async () => {
+          const openStream = mock.fn((opts: OpenStreamOptions) =>
+            Readable.from(Buffer.from("this is the file 1 content")),
+          );
+
+          const reader = new ZipReader(
+            randomAccessReaderFromBuffer(Zip32WithThreeEntries),
+            Zip32WithThreeEntries.byteLength,
+            { openStream },
+          );
+
+          const firstEntryResult = await reader.files().next();
+          assert(!firstEntryResult.done);
+          const firstEntry = firstEntryResult.value;
+
+          const fileData = await text(firstEntry.open());
+
+          const expectedContent = "this is the file 1 content";
+          assert.strictEqual(fileData, expectedContent);
+
+          assert.strictEqual(openStream.mock.callCount(), 1);
+        });
       });
     });
 

--- a/exports/reader.test.ts
+++ b/exports/reader.test.ts
@@ -14,7 +14,7 @@ import {
 import { ZipEntry, ZipEntryReader } from "./entry.ts";
 import {
   CentralDirectoryBufferReader,
-  CentralDirectoryRandomAccessReader,
+  CentralDirectoryStreamReader,
 } from "./raw/central-directory-header.ts";
 import { CompressionMethod, ZipPlatform, ZipVersion } from "./raw/constants.ts";
 import { UnixFileAttributes } from "./raw/file-attributes.ts";
@@ -398,7 +398,7 @@ describe("exports/reader", () => {
 
         assert.strictEqual(entryCount, fileCount);
         assert.strictEqual(totalSize, directory.size);
-        assertInstanceOf(directory, CentralDirectoryRandomAccessReader);
+        assertInstanceOf(directory, CentralDirectoryStreamReader);
 
         // we read one extra for the initial trailer read
         const totalBlocks = Math.ceil(totalSize / bufferSize) + 1;

--- a/exports/reader.test.ts
+++ b/exports/reader.test.ts
@@ -400,16 +400,8 @@ describe("exports/reader", () => {
         assert.strictEqual(totalSize, directory.size);
         assertInstanceOf(directory, CentralDirectoryRandomAccessReader);
 
-        // The stream actually reads overlapping blocks to avoid having to copy
-        // partial chunks, because generally the zip entry size is quite small
-        // and there's no benefit to trying to minimize the overlap. So here we
-        // calculate the number of blocks we have to read in order to cover all
-        // the entries, taking into account that we can only read a whole number
-        // per read.
-        const entrySize = totalSize / fileCount;
-        const entriesPerBlock = Math.floor(bufferSize / entrySize);
         // we read one extra for the initial trailer read
-        const totalBlocks = Math.ceil(fileCount / entriesPerBlock) + 1;
+        const totalBlocks = Math.ceil(totalSize / bufferSize) + 1;
 
         assert.strictEqual(read.mock.callCount(), totalBlocks);
       });

--- a/exports/reader.ts
+++ b/exports/reader.ts
@@ -1,12 +1,21 @@
 import { assert } from "../util/assert.ts";
-import { read, type RandomAccessReader } from "../util/streams.ts";
+import {
+  normalizeByteSource,
+  RandomAccessReaderStream,
+  read,
+  readableStreamFromDeferred,
+  type ByteSource,
+  type ByteSourceProvider,
+  type RandomAccessReader,
+} from "../util/streams.ts";
 import { ZipEntryReader } from "./entry.ts";
 import {
   CentralDirectoryBufferReader,
   CentralDirectoryHeader,
-  CentralDirectoryRandomAccessReader,
+  CentralDirectoryStreamReader,
   type CentralDirectoryReader,
 } from "./raw/central-directory-header.ts";
+import { LocalFileHeader } from "./raw/local-file-header.ts";
 import {
   Eocdr,
   Zip64Eocdl,
@@ -15,10 +24,26 @@ import {
 } from "./raw/zip-trailer.ts";
 
 /**
+ * Options for {@link ZipReaderOptions.openStream}.
+ */
+export type OpenStreamOptions = {
+  startPosition: number;
+  length: number;
+};
+
+/**
  * Options for {@link ZipReader} instance.
  */
 export type ZipReaderOptions = {
+  /**
+   * How many bytes to read from the underlying source at a time.
+   */
   bufferSize?: number | undefined;
+  /**
+   * A custom implementation for getting a stream of data. If not provided, the
+   * data will be read in chunks via the {@link RandomAccessReader}.
+   */
+  openStream?: ((options: OpenStreamOptions) => ByteSource) | undefined;
 };
 
 /**
@@ -35,6 +60,10 @@ export class ZipReader
   readonly #fileSize: number;
   readonly #reader: RandomAccessReader;
 
+  readonly #openStream:
+    | ((options: OpenStreamOptions) => ByteSource)
+    | undefined;
+
   #directory: CentralDirectoryReader | undefined;
   #pendingOpen: Promise<CentralDirectoryReader> | undefined;
 
@@ -42,16 +71,23 @@ export class ZipReader
    * Get the file comment, if set.
    */
   public get comment(): string {
+    return this.directory.comment;
+  }
+
+  /**
+   * Get the zip's central directory. You must call {@link ZipReader.open}
+   * first.
+   */
+  public get directory(): CentralDirectoryReader {
     assert(this.#directory, `call open() first`);
-    return this.#directory.comment;
+    return this.#directory;
   }
 
   /**
    * Get the total number of entries in the zip.
    */
   public get entryCount(): number {
-    assert(this.#directory, `call open() first`);
-    return this.#directory.count;
+    return this.directory.count;
   }
 
   public constructor(
@@ -62,10 +98,11 @@ export class ZipReader
     this.#bufferSize = options.bufferSize ?? ZipReader.DefaultBufferSize;
     this.#fileSize = fileSize;
     this.#reader = reader;
+    this.#openStream = options.openStream;
 
     assert(
       this.#bufferSize >= ZipReader.MinBufferSize,
-      `buffer size must be at least ${Eocdr.MaxSize + Zip64Eocdl.FixedSize}`,
+      `buffer size must be at least ${Eocdr.MaxSize + Zip64Eocdl.FixedSize} bytes`,
     );
   }
 
@@ -109,12 +146,8 @@ export class ZipReader
   public async *files(): AsyncGenerator<ZipEntryReader> {
     const directory = await this.open();
 
-    for await (const entry of directory) {
-      yield ZipEntryReader.fromRandomAccessReader(
-        entry,
-        this.#reader,
-        this.#bufferSize,
-      );
+    for await (const header of directory) {
+      yield new ZipEntryReader(header, this.makeEntryStreamProvider(header));
     }
   }
 
@@ -130,6 +163,64 @@ export class ZipReader
     }
     this.#directory = await this.#pendingOpen;
     return this.#directory;
+  }
+
+  protected makeEntryStreamProvider(
+    entry: CentralDirectoryHeader,
+  ): ByteSourceProvider {
+    let localHeaderLength: number | undefined;
+    let pendingLocalHeaderLength: Promise<number> | undefined;
+
+    const readLocalHeaderLength = async (): Promise<number> => {
+      const buffer = new Uint8Array(LocalFileHeader.FixedSize);
+
+      await read(this.#reader, {
+        buffer,
+        minLength: LocalFileHeader.FixedSize,
+        position: entry.localHeaderOffset,
+      });
+
+      localHeaderLength = LocalFileHeader.readTotalSize(buffer);
+      return localHeaderLength;
+    };
+
+    return () => {
+      if (localHeaderLength !== undefined) {
+        return this.openStream({
+          length: entry.compressedSize,
+          startPosition: entry.localHeaderOffset + localHeaderLength,
+        });
+      }
+      pendingLocalHeaderLength ??= readLocalHeaderLength();
+
+      return readableStreamFromDeferred(
+        pendingLocalHeaderLength.then((localHeaderLength) =>
+          this.openStream({
+            length: entry.compressedSize,
+            startPosition: entry.localHeaderOffset + localHeaderLength,
+          }),
+        ),
+      );
+    };
+  }
+
+  protected openDirectoryStream(trailer: ZipTrailer): ByteSource {
+    return this.openStream({
+      length: trailer.size,
+      startPosition: trailer.offset,
+    });
+  }
+
+  protected openStream(options: OpenStreamOptions): ReadableStream<Uint8Array> {
+    if (this.#openStream) {
+      return normalizeByteSource(this.#openStream(options));
+    }
+    return new RandomAccessReaderStream({
+      bufferSize: this.#bufferSize,
+      length: options.length,
+      reader: this.#reader,
+      startPosition: options.startPosition,
+    });
   }
 
   async #readCentralDirectory(): Promise<CentralDirectoryReader> {
@@ -150,19 +241,21 @@ export class ZipReader
     const eocdl = Zip64Eocdl.find(buffer, eocdrOffset);
 
     if (!eocdl) {
+      const trailer = new ZipTrailer(eocdr);
+
       if (eocdr.offset >= position) {
         // we already read all of the central directory into the buffer
         return new CentralDirectoryBufferReader(
-          new ZipTrailer(eocdr),
+          trailer,
           buffer,
           eocdr.offset - position,
         );
       }
+
       // we don't have the whole directory, so stream it instead
-      return new CentralDirectoryRandomAccessReader(new ZipTrailer(eocdr), {
-        reader: this.#reader,
-        bufferSize: this.#bufferSize,
-      });
+      return new CentralDirectoryStreamReader(trailer, () =>
+        this.openDirectoryStream(trailer),
+      );
     }
 
     let zip64eocdr: Zip64Eocdr;
@@ -201,9 +294,8 @@ export class ZipReader
       }
     }
     // we don't have the whole directory, so stream it instead
-    return new CentralDirectoryRandomAccessReader(trailer, {
-      reader: this.#reader,
-      bufferSize: this.#bufferSize,
-    });
+    return new CentralDirectoryStreamReader(trailer, () =>
+      this.openDirectoryStream(trailer),
+    );
   }
 }

--- a/exports/reader.ts
+++ b/exports/reader.ts
@@ -109,7 +109,7 @@ export class ZipReader
   /**
    * Get an iterator which iterates over the file entries in the zip.
    */
-  public [Symbol.asyncIterator](): AsyncIterator<ZipEntryReader> {
+  public [Symbol.asyncIterator](): AsyncIterator<ZipEntryReader, void, void> {
     return this.files();
   }
 
@@ -143,7 +143,7 @@ export class ZipReader
   /**
    * Get an iterator which iterates over the file entries in the zip.
    */
-  public async *files(): AsyncGenerator<ZipEntryReader> {
+  public async *files(): AsyncIterableIterator<ZipEntryReader, void, void> {
     const directory = await this.open();
 
     for await (const header of directory) {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "clean": "rm -rf lib/",
     "check": "tsc",
     "compile": "tsc -p tsconfig.build.json",
-    "coverage": "c8 node --test-reporter=dot --test '**/*.test.ts'",
+    "coverage": "c8 node --test '**/*.test.ts'",
     "lint": "eslint",
     "release": "release-it -VV",
     "test": "c8 --100 node --test-reporter=spec --test '**/*.test.*'",

--- a/test-util/fixtures.ts
+++ b/test-util/fixtures.ts
@@ -29,58 +29,7 @@ export const EmptyZip32 = data(
   cp437`Gordon is cool`, // .ZIP file comment
 );
 
-export const Zip32WithThreeEntries = data(
-  //// +0000 LOCAL ENTRY 1 HEADER (30+6+0 = 36 bytes)
-  longUint(0x04034b50), // local header signature
-  shortUint(20), // version needed (20 = 2.0)
-  shortUint(0), // flags
-  shortUint(0), // compression method (0 = NONE)
-  dosDate`2023-04-05T11:22:34Z`, // last modified
-  crc32`this is the file 1 content`, // crc32
-  utf8length32`this is the file 1 content`, // compressed size
-  utf8length32`this is the file 1 content`, // uncompressed size
-  cp437length`path 1`, // file name length
-  shortUint(0), // extra field length
-  cp437`path 1`, // file name
-  "", // extra field
-
-  //// +0036 LOCAL ENTRY 1 CONTENT (26 bytes)
-  utf8`this is the file 1 content`,
-
-  //// +0062 LOCAL ENTRY 2 HEADER (30+12+0 = 42 bytes)
-  longUint(0x04034b50), // local header signature
-  shortUint(20), // version needed (20 = 2.0)
-  shortUint(0), // flags
-  shortUint(8), // compression method (8 = DEFLATE)
-  dosDate`1994-03-02T22:44:08Z`, // last modified
-  crc32`file 2 content goes right here`, // crc32
-  deflateLength32`file 2 content goes right here`, // compressed size
-  utf8length32`file 2 content goes right here`, // uncompressed size
-  utf8length`path 2️⃣`, // file name length
-  shortUint(0), // extra field length
-  utf8`path 2️⃣`, // file name length
-  "", // extra field
-
-  //// +0104 LOCAL ENTRY 2 CONTENT (32 bytes)
-  deflate`file 2 content goes right here`,
-
-  //// +0136 LOCAL ENTRY 3 HEADER (30+7+0 = 36 bytes)
-  longUint(0x04034b50), // local header signature
-  shortUint(20), // version needed (20 = 2.0)
-  shortUint(0), // flags
-  shortUint(0), // compression method (0 = NONE)
-  dosDate`2001-09-10T09:23:02Z`, // last modified
-  crc32`this is the file 1 content`, // crc32
-  longUint(0), // compressed size
-  longUint(0), // uncompressed size
-  cp437length`path 3/`, // file name length
-  shortUint(0), // extra field length
-  cp437`path 3/`, // file name
-  "", // extra field
-
-  //// +0173 LOCAL ENTRY 3 CONTENT (0 bytes)
-  "",
-
+export const Zip32CentralDirectoryWithThreeEntries = data(
   //// +0173 DIRECTORY ENTRY 1 (46+6+0+9 = 61 bytes)
   longUint(0x02014b50), // central directory header signature
   shortUint(20 | (3 << 8)), // version made by (20 = 2.0), platform (3 = Unix)
@@ -143,6 +92,61 @@ export const Zip32WithThreeEntries = data(
   cp437`path 3/`, // file name
   "", // extra field
   cp437`comment 3`, // the comment
+);
+
+export const Zip32WithThreeEntries = data(
+  //// +0000 LOCAL ENTRY 1 HEADER (30+6+0 = 36 bytes)
+  longUint(0x04034b50), // local header signature
+  shortUint(20), // version needed (20 = 2.0)
+  shortUint(0), // flags
+  shortUint(0), // compression method (0 = NONE)
+  dosDate`2023-04-05T11:22:34Z`, // last modified
+  crc32`this is the file 1 content`, // crc32
+  utf8length32`this is the file 1 content`, // compressed size
+  utf8length32`this is the file 1 content`, // uncompressed size
+  cp437length`path 1`, // file name length
+  shortUint(0), // extra field length
+  cp437`path 1`, // file name
+  "", // extra field
+
+  //// +0036 LOCAL ENTRY 1 CONTENT (26 bytes)
+  utf8`this is the file 1 content`,
+
+  //// +0062 LOCAL ENTRY 2 HEADER (30+12+0 = 42 bytes)
+  longUint(0x04034b50), // local header signature
+  shortUint(20), // version needed (20 = 2.0)
+  shortUint(0), // flags
+  shortUint(8), // compression method (8 = DEFLATE)
+  dosDate`1994-03-02T22:44:08Z`, // last modified
+  crc32`file 2 content goes right here`, // crc32
+  deflateLength32`file 2 content goes right here`, // compressed size
+  utf8length32`file 2 content goes right here`, // uncompressed size
+  utf8length`path 2️⃣`, // file name length
+  shortUint(0), // extra field length
+  utf8`path 2️⃣`, // file name length
+  "", // extra field
+
+  //// +0104 LOCAL ENTRY 2 CONTENT (32 bytes)
+  deflate`file 2 content goes right here`,
+
+  //// +0136 LOCAL ENTRY 3 HEADER (30+7+0 = 36 bytes)
+  longUint(0x04034b50), // local header signature
+  shortUint(20), // version needed (20 = 2.0)
+  shortUint(0), // flags
+  shortUint(0), // compression method (0 = NONE)
+  dosDate`2001-09-10T09:23:02Z`, // last modified
+  crc32`this is the file 1 content`, // crc32
+  longUint(0), // compressed size
+  longUint(0), // uncompressed size
+  cp437length`path 3/`, // file name length
+  shortUint(0), // extra field length
+  cp437`path 3/`, // file name
+  "", // extra field
+
+  //// +0173 LOCAL ENTRY 3 CONTENT (0 bytes)
+  "",
+
+  Zip32CentralDirectoryWithThreeEntries,
 
   //// +0369 End of Central Directory Record
   longUint(0x06054b50), // EOCDR signature

--- a/util/streams.test.ts
+++ b/util/streams.test.ts
@@ -1,14 +1,17 @@
 import assert from "node:assert";
 import { Readable } from "node:stream";
-import { buffer } from "node:stream/consumers";
-import { describe, it } from "node:test";
+import { buffer, text } from "node:stream/consumers";
+import { describe, it, mock } from "node:test";
 import { ZipFormatError } from "../exports/errors.ts";
-import { assertBufferEqual } from "../test-util/assert.ts";
+import { assertBufferEqual, assertInstanceOf } from "../test-util/assert.ts";
 import { data, utf8 } from "../test-util/data.ts";
 import {
+  fallbackReadableStreamFromAsyncIterable,
   normalizeDataSource,
   randomAccessReaderFromBuffer,
   read,
+  readableStreamFromDeferred,
+  readableStreamFromIterable,
 } from "./streams.ts";
 
 describe("util/streams", () => {
@@ -154,6 +157,220 @@ describe("util/streams", () => {
       const expected = utf8`one,two,three,`;
 
       assertBufferEqual(output, expected);
+    });
+  });
+
+  describe("function fallbackReadableStreamFromAsyncIterable()", () => {
+    it("converts an AsyncIterable to a ReadableStream", async () => {
+      const input = Readable.from([
+        Buffer.from("one,"),
+        Buffer.from("two,"),
+        Buffer.from("three"),
+      ]);
+
+      const readable = fallbackReadableStreamFromAsyncIterable(input);
+      assertInstanceOf(readable, ReadableStream);
+
+      const output = await text(readable);
+
+      assert.strictEqual(output, "one,two,three");
+    });
+
+    it("propagates cancel", async () => {
+      const returnFn = mock.fn(
+        async (reason: unknown) => ({ done: true, value: undefined }) as const,
+      );
+
+      const input: AsyncIterableIterator<Uint8Array> = {
+        [Symbol.asyncIterator]() {
+          return this;
+        },
+
+        next: async () => ({ done: true, value: undefined }),
+        return: returnFn,
+      };
+
+      const readable = fallbackReadableStreamFromAsyncIterable(input);
+      assertInstanceOf(readable, ReadableStream);
+
+      const reader = readable.getReader();
+
+      const reason = Symbol();
+      await reader.cancel(reason);
+
+      assert.strictEqual(returnFn.mock.callCount(), 1);
+      assert.strictEqual(returnFn.mock.calls[0]?.arguments[0], reason);
+    });
+
+    it("accepts iterators with no return() method", async () => {
+      const input: AsyncIterableIterator<Uint8Array> = {
+        [Symbol.asyncIterator]() {
+          return this;
+        },
+
+        next: async () => ({ done: true, value: undefined }),
+      };
+
+      const readable = fallbackReadableStreamFromAsyncIterable(input);
+      assertInstanceOf(readable, ReadableStream);
+
+      const reader = readable.getReader();
+
+      const reason = Symbol();
+      await reader.cancel(reason);
+    });
+
+    it("throws TypeError if the iterable returns something other than an object", async () => {
+      const input: AsyncIterableIterator<Uint8Array> = {
+        [Symbol.asyncIterator]() {
+          return this;
+        },
+
+        next: async () => 2 as any,
+      };
+
+      const readable = fallbackReadableStreamFromAsyncIterable(input);
+      assertInstanceOf(readable, ReadableStream);
+
+      const reader = readable.getReader();
+
+      await assert.rejects(
+        () => reader.read(),
+        (error) =>
+          error instanceof TypeError &&
+          "code" in error &&
+          error.code === "ERR_INVALID_STATE",
+      );
+    });
+  });
+
+  describe("function readableStreamFromIterable()", () => {
+    it("converts an Iterable to a ReadableStream", async () => {
+      const input = [
+        Buffer.from("one,"),
+        Buffer.from("two,"),
+        Buffer.from("three"),
+      ];
+
+      const readable = readableStreamFromIterable(input);
+      assertInstanceOf(readable, ReadableStream);
+
+      const output = await text(readable);
+
+      assert.strictEqual(output, "one,two,three");
+    });
+
+    it("propagates cancel", async () => {
+      const returnFn = mock.fn(
+        (reason: unknown) => ({ done: true, value: undefined }) as const,
+      );
+
+      const input: IterableIterator<Uint8Array> = {
+        [Symbol.iterator]() {
+          return this;
+        },
+
+        next: () => ({ done: true, value: undefined }),
+        return: returnFn,
+      };
+
+      const readable = readableStreamFromIterable(input);
+      assertInstanceOf(readable, ReadableStream);
+
+      const reader = readable.getReader();
+
+      const reason = Symbol();
+      await reader.cancel(reason);
+
+      assert.strictEqual(returnFn.mock.callCount(), 1);
+      assert.strictEqual(returnFn.mock.calls[0]?.arguments[0], reason);
+    });
+
+    it("accepts iterators with no return() method", async () => {
+      const input: IterableIterator<Uint8Array> = {
+        [Symbol.iterator]() {
+          return this;
+        },
+
+        next: () => ({ done: true, value: undefined }),
+      };
+
+      const readable = readableStreamFromIterable(input);
+      assertInstanceOf(readable, ReadableStream);
+
+      const reader = readable.getReader();
+
+      const reason = Symbol();
+      await reader.cancel(reason);
+    });
+
+    it("throws TypeError if the iterable returns something other than an object", async () => {
+      const input: IterableIterator<Uint8Array> = {
+        [Symbol.iterator]() {
+          return this;
+        },
+
+        next: () => 2 as any,
+      };
+
+      const readable = readableStreamFromIterable(input);
+      assertInstanceOf(readable, ReadableStream);
+
+      const reader = readable.getReader();
+
+      await assert.rejects(
+        () => reader.read(),
+        (error) =>
+          error instanceof TypeError &&
+          "code" in error &&
+          error.code === "ERR_INVALID_STATE",
+      );
+    });
+
+    describe("function readableStreamFromDeferred()", () => {
+      it("returns the correct data", async () => {
+        const source = Promise.resolve(
+          new ReadableStream<Uint8Array>({
+            start: (controller) => {
+              controller.enqueue(Buffer.from("hello "));
+              controller.enqueue(Buffer.from("world"));
+              controller.close();
+            },
+          }),
+        );
+
+        const result = readableStreamFromDeferred(source);
+        assertInstanceOf(result, ReadableStream);
+
+        const data = await text(result);
+        assert.strictEqual(data, "hello world");
+      });
+
+      it("propagates cancel", async () => {
+        const cancel = mock.fn((reason: unknown) => {});
+
+        const source = Promise.resolve(
+          new ReadableStream<Uint8Array>({
+            start: (controller) => {
+              controller.enqueue(Buffer.from("hello "));
+              controller.enqueue(Buffer.from("world"));
+              controller.close();
+            },
+            cancel,
+          }),
+        );
+
+        const result = readableStreamFromDeferred(source);
+        assertInstanceOf(result, ReadableStream);
+
+        const reader = result.getReader();
+
+        const reason = Symbol();
+        await reader.cancel(reason);
+
+        assert.strictEqual(cancel.mock.callCount(), 1);
+        assert.strictEqual(cancel.mock.calls[0]?.arguments[0], reason);
+      });
     });
   });
 });

--- a/util/streams.ts
+++ b/util/streams.ts
@@ -264,10 +264,15 @@ export function readableStreamFromDeferred<T>(
 ): ReadableStream<T> {
   let reader: ReadableStreamDefaultReader<T>;
 
+  const readerPromise = promise.then((readable) => {
+    reader = readable.getReader();
+    return reader;
+  });
+
   return new ReadableStream<T>({
     start: async () => {
-      const readable = await promise;
-      reader = readable.getReader();
+      // make sure we're initialized before calling pull()
+      await readerPromise;
     },
 
     pull: async (controller) => {
@@ -280,15 +285,14 @@ export function readableStreamFromDeferred<T>(
     },
 
     cancel: async (reason) => {
+      // need to await this again because ReadableStream doesn't wait until
+      // start() is finished before calling cancel()
+      const reader = await readerPromise;
       await reader.cancel(reason);
     },
   });
 }
 
-/**
- * This isn't available everywhere yet.
- * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/from_static}
- */
 function readableStreamFromAsyncIterable<T>(
   asyncIterable: AsyncIterable<T>,
 ): ReadableStream<T> {
@@ -298,7 +302,17 @@ function readableStreamFromAsyncIterable<T>(
       asyncIterable,
     );
   }
+  /* c8 ignore next */
+  return fallbackReadableStreamFromAsyncIterable(asyncIterable);
+}
 
+/**
+ * This isn't available everywhere yet.
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/from_static}
+ */
+export function fallbackReadableStreamFromAsyncIterable<T>(
+  asyncIterable: AsyncIterable<T>,
+): ReadableStream<T> {
   // Spec: https://streams.spec.whatwg.org/#readable-stream-from-iterable
   // 2.
   const iteratorRecord = asyncIterable[Symbol.asyncIterator]();
@@ -309,7 +323,7 @@ function readableStreamFromAsyncIterable<T>(
     // 4.1 - 4.4
     const iterResult = await iteratorRecord.next();
     // 4.4.1
-    assertIteratorResultObject(iterResult);
+    assertIteratorResultObject(iterResult, "async", "next");
     // 4.4.2
     if (iterResult.done) {
       // 4.4.3
@@ -330,7 +344,7 @@ function readableStreamFromAsyncIterable<T>(
     // 5.5-5.7
     const iterResult = await iteratorRecord.return(reason);
     // 5.8
-    assertIteratorResultObject(iterResult);
+    assertIteratorResultObject(iterResult, "async", "return");
   };
 
   // 6.-7.
@@ -346,14 +360,14 @@ function readableStreamFromAsyncIterable<T>(
 /**
  * This is the synchronous analog of {@link readableStreamFromAsyncIterable}.
  */
-function readableStreamFromIterable<T>(
+export function readableStreamFromIterable<T>(
   iterable: Iterable<T>,
 ): ReadableStream<T> {
   const iteratorRecord = iterable[Symbol.iterator]();
 
   const pullAlgorithm: UnderlyingDefaultSource<T>["pull"] = (controller) => {
     const iterResult = iteratorRecord.next();
-    assertIteratorResultObject(iterResult);
+    assertIteratorResultObject(iterResult, "sync", "next");
     if (iterResult.done) {
       controller.close();
     } else {
@@ -365,7 +379,7 @@ function readableStreamFromIterable<T>(
       return;
     }
     const iterResult = iteratorRecord.return(reason);
-    assertIteratorResultObject(iterResult);
+    assertIteratorResultObject(iterResult, "sync", "return");
   };
 
   return new ReadableStream<T>(
@@ -377,11 +391,17 @@ function readableStreamFromIterable<T>(
   );
 }
 
-function assertIteratorResultObject(value: unknown): asserts value is object {
+function assertIteratorResultObject(
+  value: unknown,
+  type: "async" | "sync",
+  method: "next" | "return",
+): asserts value is object {
   if (typeof value !== "object") {
     throw Object.assign(
       new TypeError(
-        "The promise returned by the iterator.next() method must fulfill with an object",
+        type === "async"
+          ? `The promise returned by the iterator.${method}() method must fulfill with an object`
+          : `The value returned by the iterator.${method}() method be an object`,
       ),
       { code: "ERR_INVALID_STATE" },
     );

--- a/util/streams.ts
+++ b/util/streams.ts
@@ -3,7 +3,9 @@ import { assert } from "./assert.ts";
 import { computeCrc32 } from "./crc32.ts";
 
 export type AnyIterable<T> = AsyncIterable<T> | Iterable<T>;
-export type ByteSource = AnyIterable<Uint8Array>;
+export type ByteStream = AnyIterable<Uint8Array>;
+export type ByteSource = AnyIterable<Uint8Array> | Uint8Array;
+export type ByteSourceProvider = Uint8Array | (() => ByteSource);
 
 export type RandomAccessReadOptions = {
   buffer: Uint8Array;
@@ -93,62 +95,18 @@ export type RandomAccessReaderStreamOptions = {
   bufferSize?: number | undefined;
   reader: RandomAccessReader;
   startPosition: number;
-} & (
-  | {
-      header: (firstChunk: Uint8Array) => ReaderDataInfo;
-      headerMinLength: number;
-    }
-  | {
-      length: number;
-    }
-);
+  length: number;
+};
 
 export class RandomAccessReaderStream extends ReadableStream<Uint8Array> {
   public constructor(options: RandomAccessReaderStreamOptions) {
     const { bufferSize = 128 * 1024, reader } = options;
 
     let position = options.startPosition;
-    let endPosition: number | undefined;
-
-    if ("length" in options) {
-      endPosition = position + options.length;
-    }
+    const endPosition = position + options.length;
 
     super({
-      start: async (controller) => {
-        const buffer = new Uint8Array(bufferSize);
-
-        if (!("header" in options)) {
-          return;
-        }
-
-        const length = await read(reader, {
-          buffer,
-          position,
-          minLength: options.headerMinLength,
-        });
-
-        const dataInfo = options.header(buffer);
-        const skipBytes = dataInfo.startPosition - position;
-        const firstChunkLength = Math.min(length - skipBytes, dataInfo.length);
-        position = dataInfo.startPosition;
-        endPosition = dataInfo.startPosition + dataInfo.length;
-
-        if (firstChunkLength > 0) {
-          const firstChunk = buffer.subarray(
-            skipBytes,
-            skipBytes + firstChunkLength,
-          );
-          controller.enqueue(firstChunk);
-          position += firstChunkLength;
-        }
-        if (position === endPosition) {
-          controller.close();
-        }
-      },
-
       pull: async (controller) => {
-        assert(endPosition !== undefined);
         const remaining = endPosition - position;
         if (remaining === 0) {
           controller.close();
@@ -196,59 +154,73 @@ export function randomAccessReaderFromBuffer(
   };
 }
 
+export function normalizeByteSource(
+  data: ByteSource,
+): ReadableStream<Uint8Array> {
+  if (data instanceof ReadableStream) {
+    return data as ReadableStream<Uint8Array>;
+  }
+  if (data instanceof Uint8Array) {
+    return readableStreamFromIterable([data]);
+  }
+  if (Symbol.iterator in data) {
+    return readableStreamFromIterable(data);
+  }
+  return readableStreamFromAsyncIterable(data);
+}
+
+export function normalizeByteSourceProvider(
+  provider: ByteSourceProvider,
+): () => ReadableStream<Uint8Array> {
+  if (provider instanceof Uint8Array) {
+    return () => normalizeByteSource(provider);
+  }
+  return () => normalizeByteSource(provider());
+}
+
 export function normalizeDataSource(
   data: DataSource | undefined,
 ): ReadableStream<Uint8Array> {
   // we can't assume that if data is already a ReadableStream that it has
   // Uint8Array chunks, so we still need to wrap it.
 
-  let iterator:
-    | AsyncIterator<Uint8Array | string>
-    | Iterator<Uint8Array | string>
-    | undefined;
+  if (!data) {
+    return readableStreamFromIterable([]);
+  }
+  if (typeof data === "string") {
+    return readableStreamFromIterable([new TextEncoder().encode(data)]);
+  }
+  if (data instanceof Uint8Array) {
+    return readableStreamFromIterable([data]);
+  }
 
   let encoder: TextEncoder | undefined;
-
-  return new ReadableStream<Uint8Array>({
-    start: (controller) => {
-      if (data === undefined) {
-        controller.close();
-      } else if (typeof data === "string") {
-        if (data.length > 0) {
-          controller.enqueue(new TextEncoder().encode(data));
+  if (Symbol.iterator in data) {
+    return readableStreamFromIterable(
+      (function* () {
+        for (const chunk of data) {
+          if (typeof chunk === "string") {
+            encoder ??= new TextEncoder();
+            yield encoder.encode(chunk);
+          } else {
+            yield chunk;
+          }
         }
-        controller.close();
-      } else if (data instanceof Uint8Array) {
-        if (data.byteLength > 0) {
-          controller.enqueue(data);
+      })(),
+    );
+  }
+  return readableStreamFromAsyncIterable(
+    (async function* () {
+      for await (const chunk of data) {
+        if (typeof chunk === "string") {
+          encoder ??= new TextEncoder();
+          yield encoder.encode(chunk);
+        } else {
+          yield chunk;
         }
-        controller.close();
-      } else if (Symbol.asyncIterator in data) {
-        iterator = data[Symbol.asyncIterator]();
-      } else if (Symbol.iterator in data) {
-        iterator = data[Symbol.iterator]();
       }
-    },
-
-    pull: async (controller) => {
-      assert(iterator);
-
-      const next = await iterator.next();
-      if (typeof next.value === "string") {
-        encoder ??= new TextEncoder();
-        controller.enqueue(encoder.encode(next.value));
-      } else if (next.value !== undefined) {
-        assert(
-          next.value instanceof Uint8Array,
-          `expected Uint8Array or string`,
-        );
-        controller.enqueue(next.value);
-      }
-      if (next.done) {
-        controller.close();
-      }
-    },
-  });
+    })(),
+  );
 }
 
 /**
@@ -284,5 +256,134 @@ export class Crc32Stream extends TransformStream<Uint8Array, Uint8Array> {
         callback(result);
       },
     });
+  }
+}
+
+export function readableStreamFromDeferred<T>(
+  promise: PromiseLike<ReadableStream<T>>,
+): ReadableStream<T> {
+  let reader: ReadableStreamDefaultReader<T>;
+
+  return new ReadableStream<T>({
+    start: async () => {
+      const readable = await promise;
+      reader = readable.getReader();
+    },
+
+    pull: async (controller) => {
+      const { value, done } = await reader.read();
+      if (done) {
+        controller.close();
+      } else {
+        controller.enqueue(value);
+      }
+    },
+
+    cancel: async (reason) => {
+      await reader.cancel(reason);
+    },
+  });
+}
+
+/**
+ * This isn't available everywhere yet.
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/from_static}
+ */
+function readableStreamFromAsyncIterable<T>(
+  asyncIterable: AsyncIterable<T>,
+): ReadableStream<T> {
+  // use the provided version if it exists
+  if ("from" in ReadableStream && typeof ReadableStream.from === "function") {
+    return (ReadableStream.from as typeof readableStreamFromAsyncIterable)(
+      asyncIterable,
+    );
+  }
+
+  // Spec: https://streams.spec.whatwg.org/#readable-stream-from-iterable
+  // 2.
+  const iteratorRecord = asyncIterable[Symbol.asyncIterator]();
+  // 4.
+  const pullAlgorithm: UnderlyingDefaultSource<T>["pull"] = async (
+    controller,
+  ) => {
+    // 4.1 - 4.4
+    const iterResult = await iteratorRecord.next();
+    // 4.4.1
+    assertIteratorResultObject(iterResult);
+    // 4.4.2
+    if (iterResult.done) {
+      // 4.4.3
+      controller.close();
+    } else {
+      // 4.4.2
+      controller.enqueue(iterResult.value);
+    }
+  };
+  // 5.
+  const cancelAlgorithm: UnderlyingDefaultSource<T>["cancel"] = async (
+    reason,
+  ) => {
+    // 5.3
+    if (iteratorRecord.return === undefined) {
+      return;
+    }
+    // 5.5-5.7
+    const iterResult = await iteratorRecord.return(reason);
+    // 5.8
+    assertIteratorResultObject(iterResult);
+  };
+
+  // 6.-7.
+  return new ReadableStream<T>(
+    {
+      pull: pullAlgorithm,
+      cancel: cancelAlgorithm,
+    },
+    { highWaterMark: 0 },
+  );
+}
+
+/**
+ * This is the synchronous analog of {@link readableStreamFromAsyncIterable}.
+ */
+function readableStreamFromIterable<T>(
+  iterable: Iterable<T>,
+): ReadableStream<T> {
+  const iteratorRecord = iterable[Symbol.iterator]();
+
+  const pullAlgorithm: UnderlyingDefaultSource<T>["pull"] = (controller) => {
+    const iterResult = iteratorRecord.next();
+    assertIteratorResultObject(iterResult);
+    if (iterResult.done) {
+      controller.close();
+    } else {
+      controller.enqueue(iterResult.value);
+    }
+  };
+  const cancelAlgorithm: UnderlyingDefaultSource<T>["cancel"] = (reason) => {
+    if (iteratorRecord.return === undefined) {
+      return;
+    }
+    const iterResult = iteratorRecord.return(reason);
+    assertIteratorResultObject(iterResult);
+  };
+
+  return new ReadableStream<T>(
+    {
+      pull: pullAlgorithm,
+      cancel: cancelAlgorithm,
+    },
+    { highWaterMark: 0 },
+  );
+}
+
+function assertIteratorResultObject(value: unknown): asserts value is object {
+  if (typeof value !== "object") {
+    throw Object.assign(
+      new TypeError(
+        "The promise returned by the iterator.next() method must fulfill with an object",
+      ),
+      { code: "ERR_INVALID_STATE" },
+    );
   }
 }

--- a/util/streams.ts
+++ b/util/streams.ts
@@ -93,9 +93,15 @@ export type RandomAccessReaderStreamOptions = {
   bufferSize?: number | undefined;
   reader: RandomAccessReader;
   startPosition: number;
-  header: (firstChunk: Uint8Array) => ReaderDataInfo;
-  headerLength: number;
-};
+} & (
+  | {
+      header: (firstChunk: Uint8Array) => ReaderDataInfo;
+      headerMinLength: number;
+    }
+  | {
+      length: number;
+    }
+);
 
 export class RandomAccessReaderStream extends ReadableStream<Uint8Array> {
   public constructor(options: RandomAccessReaderStreamOptions) {
@@ -104,14 +110,22 @@ export class RandomAccessReaderStream extends ReadableStream<Uint8Array> {
     let position = options.startPosition;
     let endPosition: number | undefined;
 
+    if ("length" in options) {
+      endPosition = position + options.length;
+    }
+
     super({
       start: async (controller) => {
         const buffer = new Uint8Array(bufferSize);
 
+        if (!("header" in options)) {
+          return;
+        }
+
         const length = await read(reader, {
           buffer,
           position,
-          minLength: options.headerLength,
+          minLength: options.headerMinLength,
         });
 
         const dataInfo = options.header(buffer);


### PR DESCRIPTION
Improve how streams are used in across the codebase and support passing a custom `openStream` function to `ZipReader` for remote scenarios.